### PR TITLE
Add jcip-annotations dependency

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -35,5 +35,10 @@
             <artifactId>jsr305</artifactId>
             <version>2.0.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.stephenc.jcip</groupId>
+            <artifactId>jcip-annotations</artifactId>
+            <version>1.0-1</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Lighthouse would not compile in Android Sudio (IntelliJ based IDE) because jcip-annotations was missing
