### PR TITLE
debugging - avoid Project View crash by displaying default project image in case of problems

### DIFF
--- a/client/src/main/java/lighthouse/controls/ProjectView.java
+++ b/client/src/main/java/lighthouse/controls/ProjectView.java
@@ -209,7 +209,14 @@ public class ProjectView extends HBox {
         noPledgesLabel.visibleProperty().bind(isEmpty(pledgesList.getItems()));
 
         // Load and set up the cover image.
-        Image img = new Image(p.getCoverImage().newInput());
+	Image img = new Image(p.getCoverImage().newInput());
+        if (img.getException() != null) {
+	    try {
+	        img = new Image(getResource("default-cover-image.png").openStream());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+	}
         if (img.getException() != null)
             Throwables.propagate(img.getException());
         BackgroundSize cover = new BackgroundSize(BackgroundSize.AUTO, BackgroundSize.AUTO, false, false, false, true);

--- a/client/src/main/java/lighthouse/controls/ProjectView.java
+++ b/client/src/main/java/lighthouse/controls/ProjectView.java
@@ -209,14 +209,14 @@ public class ProjectView extends HBox {
         noPledgesLabel.visibleProperty().bind(isEmpty(pledgesList.getItems()));
 
         // Load and set up the cover image.
-	Image img = new Image(p.getCoverImage().newInput());
+        Image img = new Image(p.getCoverImage().newInput());
         if (img.getException() != null) {
-	    try {
-	        img = new Image(getResource("default-cover-image.png").openStream());
+            try {
+                img = new Image(getResource("default-cover-image.png").openStream());
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-	}
+        }
         if (img.getException() != null)
             Throwables.propagate(img.getException());
         BackgroundSize cover = new BackgroundSize(BackgroundSize.AUTO, BackgroundSize.AUTO, false, false, false, true);


### PR DESCRIPTION

It's possible to programmatically create project files without images. The resulting files load fine right now when they are imported into Lighthouse, but the application crashes when it tries to display them on the project page.

This just avoids the interface crashing by loading the default-cover-image in cases where there is something wrong with the image in the project file.
