### PR TITLE
Fix #168 - period in a hyperlink breaks markdown formatting

### DIFF
--- a/client/src/main/java/lighthouse/controls/MarkDownNode.kt
+++ b/client/src/main/java/lighthouse/controls/MarkDownNode.kt
@@ -215,7 +215,12 @@ public class MarkDownNode : VBox() {
         override fun visit(node: ExpLinkNode) {
             val child = node.getChildren()[0].getChildren()[0]
             if (child is TextNode) {
-                link(node.url, child.getText())
+                val sbLabel = StringBuilder()
+                for (child2 in node.getChildren()[0].getChildren()) {
+                    val textNode: TextNode? = child2 as? TextNode
+                    if(textNode != null) sbLabel.append(textNode.getText())
+                }
+                link(node.url, sbLabel.toString())
             } else if (child is ExpImageNode) {
                 val imageView = ImageView(Image(child.url, true))
                 imageView.setOnMouseClicked { this@MarkDownNode.urlOpener.accept(child.url) }


### PR DESCRIPTION
Problem: Using a period in a hyperlink label was breaking the formating, causing the link label to be cut off before the period.

Cause: The ExpLinkNode handler was only reading the first TextNode in the hyperlink label.

Solution: It must read all TextNodes inside the label, and there can be more than one, because they are split by some characters.

Fixes issue #168