### PR TITLE
Fix ProjectView crash caused by uninitialized format string

### DIFF
--- a/client/src/main/java/lighthouse/controls/ProjectView.java
+++ b/client/src/main/java/lighthouse/controls/ProjectView.java
@@ -376,6 +376,7 @@ public class ProjectView extends HBox {
             loader.setClassLoader(getClass().getClassLoader());
             loader.load();
 
+            goalAmountFormatStr = goalAmountLabel.getText();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Problem: Current master branch will crash whenever user opens a project view.

Cause: Uninitialized goalAmountFormatStr. This format string was originally loaded from the goalAmountLabel component via getText() and then returned to it with values filled in using setText(). This would override a localized string, so when I was implementing the i18n, I replaced this with the usual GetText function, and put it next to the rest of the localized string loads. When you deleted the localization block, you also deleted the goalAmountFormatStr initialization, and that's why it now crashes every time the ProjectView control is opened.

Solution: Let's put it back as it was before. Now that strings are loaded at the FXML level, taking the label from a control will not break localization anymore.